### PR TITLE
Fix README link

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -33,4 +33,4 @@ You need to set your `tsconfig.json` file in your eslint configuration via `pars
 
 ## Rules
 * [js-function-in-worklet](https://github.com/wcandillon/eslint-plugin-reanimated/blob/master/docs/js-function-in-worklet.md)
-* [unsupported-syntax](https://github.com/wcandillon/eslint-plugin-reanimated/blob/master/docs/unsupported-syntax)
+* [unsupported-syntax](https://github.com/wcandillon/eslint-plugin-reanimated/blob/master/docs/unsupported-syntax.md)


### PR DESCRIPTION
In this PR:
- fix link to `unsupported-syntax` rule docs in README