### PR TITLE
Fix Rules links in README (-> relative)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,5 +32,5 @@ You need to set your `tsconfig.json` file in your eslint configuration via `pars
 ```
 
 ## Rules
-* [js-function-in-worklet](https://github.com/wcandillon/eslint-plugin-reanimated/blob/master/docs/js-function-in-worklet.md)
-* [unsupported-syntax](https://github.com/wcandillon/eslint-plugin-reanimated/blob/master/docs/unsupported-syntax)
+* [js-function-in-worklet](./docs/js-function-in-worklet.md)
+* [unsupported-syntax](./docs/unsupported-syntax.md)


### PR DESCRIPTION
Also uses relative paths so it works when opening the README from some other source than GitHub (e.g. local)