### PR TITLE
no-multiple-animated-style-usages rule

### DIFF
--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,9 +1,11 @@
 import jsFunctionInWorklet from "./js-function-in-worklet";
 import unsupportedSyntax from "./unsupported-syntax";
+import noMultipleAnimatedStyleUsages from "./no-multiple-animated-style-usages";
 
 const rules = {
   "js-function-in-worklet": jsFunctionInWorklet,
   "unsupported-syntax": unsupportedSyntax,
+  "no-multiple-animated-style-usages": noMultipleAnimatedStyleUsages,
 };
 
 export default rules;

--- a/src/rules/no-multiple-animated-style-usages.ts
+++ b/src/rules/no-multiple-animated-style-usages.ts
@@ -1,0 +1,98 @@
+import { ESLintUtils } from "@typescript-eslint/experimental-utils";
+import { Scope } from "@typescript-eslint/experimental-utils/dist/ts-eslint";
+import { TSESTree } from "@typescript-eslint/experimental-utils/dist/ts-estree";
+
+export type Options = [];
+export type MessageIds = "NoMultipleAnimatedStyleUsagesMessage";
+
+const createRule = ESLintUtils.RuleCreator((name) => {
+  return `https://github.com/wcandillon/eslint-plugin-reanimated/blob/master/docs/${name}.md`;
+});
+
+const NoMultipleAnimatedStyleUsagesMessage =
+  "{{name}} cannot be used multiple times. Use separate useAnimatedStyle() calls instead.";
+
+const getVariableInScope = (
+  name: string,
+  scope: Scope.Scope
+): Scope.Variable | undefined => {
+  const { variables } = scope;
+  const variable = variables.find((v) => v.name === name);
+  if (variable !== undefined) {
+    return variable;
+  } else if (scope.type === "function") {
+    return undefined;
+  } else if (scope.upper === null) {
+    return undefined;
+  }
+  return getVariableInScope(name, scope.upper);
+};
+
+export default createRule<Options, MessageIds>({
+  name: "no-multiple-animated-style-usages",
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Animated styles cannot be used multiple times. Call useAnimatedStyle() multiple times instead.",
+      category: "Possible Errors",
+      recommended: "error",
+    },
+    schema: [],
+    messages: {
+      NoMultipleAnimatedStyleUsagesMessage,
+    },
+  },
+  defaultOptions: [],
+  create: (context) => {
+    const definedAnimatedStyles = new Set<Scope.Definition>();
+    const styleDefinitions = new Map<Scope.Definition, TSESTree.Identifier[]>();
+    return {
+      "CallExpression[callee.name='useAnimatedStyle']": (
+        node: TSESTree.CallExpression
+      ) => {
+        const { parent } = node;
+        if (!parent) {
+          return;
+        }
+        const declaredVariables = context.getDeclaredVariables(parent);
+        const definition = declaredVariables[0]?.defs?.[0];
+        if (!definition) {
+          return;
+        }
+        definedAnimatedStyles.add(definition);
+      },
+      "JSXAttribute[name.name='style'] Identifier": (
+        node: TSESTree.Identifier
+      ) => {
+        const variable = getVariableInScope(node.name, context.getScope());
+        const definition = variable?.defs?.[0];
+        if (!definition) {
+          return;
+        }
+        if (!definedAnimatedStyles.has(definition)) {
+          return;
+        }
+        const existingIdentifiers = styleDefinitions.get(definition) ?? [];
+        styleDefinitions.set(definition, [...existingIdentifiers, node]);
+      },
+      "Program:exit": () => {
+        for (const [, identifiers] of styleDefinitions) {
+          if (identifiers.length < 2) {
+            continue;
+          }
+
+          identifiers.forEach((identifier) => {
+            context.report({
+              messageId: "NoMultipleAnimatedStyleUsagesMessage",
+              node: identifier,
+              data: {
+                name: identifier.name,
+              },
+            });
+          });
+        }
+      },
+    };
+  },
+});

--- a/tests/fixtures/invalid/multiple-animated-style-array.txt
+++ b/tests/fixtures/invalid/multiple-animated-style-array.txt
@@ -1,0 +1,21 @@
+import {StyleSheet} from 'react-native'
+import Animated, {useAnimatedStyle, useSharedValue} from 'react-native-reanimated'
+
+const Component = () => {
+  const opacity = useSharedValue(1)
+
+  const style = useAnimatedStyle(() => ({
+    opacity: opacity.value
+  }))
+
+  return (
+    <>
+      <Animated.View style={[styles.style1, style]} />
+      <Animated.View style={[style]} />
+    </>
+  )
+}
+
+const styles = StyleSheet.create({
+  style1: {},
+})

--- a/tests/fixtures/invalid/multiple-animated-style.txt
+++ b/tests/fixtures/invalid/multiple-animated-style.txt
@@ -1,0 +1,16 @@
+import Animated, {useAnimatedStyle, useSharedValue} from 'react-native-reanimated'
+
+const Component = () => {
+  const opacity = useSharedValue(1)
+
+  const style = useAnimatedStyle(() => ({
+    opacity: opacity.value
+  }))
+
+  return (
+    <>
+      <Animated.View style={style} />
+      <Animated.View style={style} />
+    </>
+  )
+}

--- a/tests/fixtures/valid/additional-references-to-animated-style.txt
+++ b/tests/fixtures/valid/additional-references-to-animated-style.txt
@@ -1,0 +1,13 @@
+import Animated, {useAnimatedStyle, useSharedValue} from 'react-native-reanimated'
+
+const Component = () => {
+  const style = useAnimatedStyle(() => ({
+    opacity: 1
+  }))
+
+  console.log({style})
+
+  return (
+    <Animated.View style={style} />
+  )
+}

--- a/tests/fixtures/valid/multiple-usage-non-animated-style.txt
+++ b/tests/fixtures/valid/multiple-usage-non-animated-style.txt
@@ -1,0 +1,14 @@
+import Animated, {useAnimatedStyle, useSharedValue} from 'react-native-reanimated'
+
+const Component = () => {
+  const style = {
+    opacity: 1
+  }
+
+  return (
+    <>
+      <Animated.View style={style} />
+      <Animated.View style={style} />
+    </>
+  )
+}

--- a/tests/fixtures/valid/same-named-animated-style.txt
+++ b/tests/fixtures/valid/same-named-animated-style.txt
@@ -1,0 +1,25 @@
+import Animated, {useAnimatedStyle, useSharedValue} from 'react-native-reanimated'
+
+const Component = () => {
+  const opacity = useSharedValue(1)
+
+  const style = useAnimatedStyle(() => ({
+    opacity: opacity.value
+  }))
+
+  return (
+    <Animated.View style={style} />
+  )
+}
+
+const OtherComponent = () => {
+  const opacity = useSharedValue(1)
+
+  const style = useAnimatedStyle(() => ({
+    opacity: opacity.value
+  }))
+
+  return (
+    <Animated.View style={style} />
+  )
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -9,6 +9,7 @@ describe('eslint-plugin ("./src/index.ts")', () => {
   const ruleKeys = Object.keys({
     jsFunctionInWorklet: true,
     unsupportedSyntax: true,
+    noMultipleAnimatedStyleUsages: true,
   }).map((rule) => camelToUnderscore(rule));
   const eslintPluginRuleKeys = Object.keys(rules);
 

--- a/tests/no-multiple-animated-style-usages.test.ts
+++ b/tests/no-multiple-animated-style-usages.test.ts
@@ -1,0 +1,49 @@
+import path from "path";
+import fs from "fs";
+
+import { ESLintUtils } from "@typescript-eslint/experimental-utils";
+
+import rule from "../src/rules/no-multiple-animated-style-usages";
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    project: "./tsconfig.eslint.json",
+    tsconfigRootDir: path.join(__dirname, "fixtures"),
+    sourceType: "module",
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+const code = (name: string) =>
+  fs.readFileSync(path.join(__dirname, name), "utf8");
+const VALID = "fixtures/valid";
+const files = fs.readdirSync(path.join(__dirname, VALID));
+const valid = files.map((file) => ({
+  code: code(path.join(VALID, file)),
+}));
+
+ruleTester.run("no-multiple-animated-style-usages", rule, {
+  valid,
+  invalid: [
+    {
+      code: code("fixtures/invalid/multiple-animated-style.txt"),
+      errors: [
+        {
+          messageId: "NoMultipleAnimatedStyleUsagesMessage",
+          data: {
+            name: "style",
+          },
+        },
+        {
+          messageId: "NoMultipleAnimatedStyleUsagesMessage",
+          data: {
+            name: "style",
+          },
+        },
+      ],
+    },
+  ],
+});

--- a/tests/no-multiple-animated-style-usages.test.ts
+++ b/tests/no-multiple-animated-style-usages.test.ts
@@ -45,5 +45,22 @@ ruleTester.run("no-multiple-animated-style-usages", rule, {
         },
       ],
     },
+    {
+      code: code("fixtures/invalid/multiple-animated-style-array.txt"),
+      errors: [
+        {
+          messageId: "NoMultipleAnimatedStyleUsagesMessage",
+          data: {
+            name: "style",
+          },
+        },
+        {
+          messageId: "NoMultipleAnimatedStyleUsagesMessage",
+          data: {
+            name: "style",
+          },
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
Fixes #19 

Adds new `no-multiple-animated-style-usages` rule for flagging attempts to use an animated style on multiple elements

TODO: I can add docs (and a link from the README) for this rule if you think this looks good