### PR TITLE
no-shared-value-coercion rule

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,3 +35,4 @@ You need to set your `tsconfig.json` file in your eslint configuration via `pars
 * [js-function-in-worklet](./docs/js-function-in-worklet.md)
 * [unsupported-syntax](./docs/unsupported-syntax.md)
 * [no-multiple-animated-style-usages](./docs/no-multiple-animated-style-usages.md)
+* [no-shared-value-coercion](./docs/no-shared-value-coercion.md)

--- a/docs/no-shared-value-coercion.md
+++ b/docs/no-shared-value-coercion.md
@@ -1,0 +1,66 @@
+# No implicit shared value coercion (`no-shared-value-coercion`)
+
+Flag accidental coercion of "raw" shared values to boolean/string where the
+intent was to refer to `.value` property
+
+The following examples are considered invalid:
+
+```ts
+const foo = useSharedValue(true);
+const bar = useDerivedValue(() => foo ? 1 : 0);
+```
+
+```ts
+const foo = useSharedValue(true);
+const bar = useDerivedValue(() => {
+  if (foo) {
+    return 1;
+  } else {
+    return 0;
+  }
+});
+```
+
+```ts
+const foo = useSharedValue(true);
+const bar = useDerivedValue(() => {
+  if (foo || somethingElse()) {
+    return 1;
+  } else {
+    return 0;
+  }
+});
+```
+
+```ts
+const foo = useSharedValue('foo');
+const bar = useDerivedValue(() =>
+  `${foo}baz`
+);
+```
+
+The following examples are considered valid:
+
+```ts
+const foo = useSharedValue(true);
+const bar = useDerivedValue(() => foo.value ? 1 : 0);
+```
+
+```ts
+const foo = useSharedValue(true);
+const bar = useDerivedValue(() => !!foo ? 1 : 0);
+```
+
+```ts
+const foo = useSharedValue('foo');
+const bar = useDerivedValue(() =>
+  `${foo.value}baz`
+);
+```
+
+```ts
+const foo = useSharedValue('foo');
+const bar = useDerivedValue(() =>
+  `${foo.toString()}baz`
+);
+```

--- a/src/rules/no-shared-value-coercion.ts
+++ b/src/rules/no-shared-value-coercion.ts
@@ -54,7 +54,7 @@ export default createRule<Options, MessageIds>({
       const typeString = checker.typeToString(
         checker.getTypeAtLocation(tsNode)
       );
-      if (!/\bSharedValue\b/.test(typeString)) {
+      if (!/\bSharedValue<.*>$/.test(typeString)) {
         return;
       }
 

--- a/src/rules/no-shared-value-coercion.ts
+++ b/src/rules/no-shared-value-coercion.ts
@@ -1,0 +1,88 @@
+import { ESLintUtils } from "@typescript-eslint/experimental-utils";
+import { TSESTree } from "@typescript-eslint/experimental-utils/dist/ts-estree";
+
+export type Options = [];
+export type MessageIds =
+  | "NoSharedValueCoercionBooleanMessage"
+  | "NoSharedValueCoercionStringMessage";
+
+const createRule = ESLintUtils.RuleCreator((name) => {
+  return `https://github.com/wcandillon/eslint-plugin-reanimated/blob/master/docs/${name}.md`;
+});
+
+const NoSharedValueCoercionBooleanMessage = "Did you mean `{{name}}.value`?";
+
+const NoSharedValueCoercionStringMessage =
+  "Did you mean `{{name}}.value`? Otherwise use `{{name}}.toString()` to be explicit.";
+
+type CoercionType = "boolean" | "string";
+const MESSAGES: Record<CoercionType, MessageIds> = {
+  boolean: "NoSharedValueCoercionBooleanMessage",
+  string: "NoSharedValueCoercionStringMessage",
+};
+const getMessageId = (coercionType: CoercionType): MessageIds =>
+  MESSAGES[coercionType];
+
+export default createRule<Options, MessageIds>({
+  name: "no-shared-value-coercion",
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        'Catch uses of "raw" shared values instead of their value property.',
+      category: "Possible Errors",
+      recommended: "error",
+    },
+    schema: [],
+    messages: {
+      NoSharedValueCoercionBooleanMessage,
+      NoSharedValueCoercionStringMessage,
+    },
+  },
+  defaultOptions: [],
+  create: (context) => {
+    const parserServices = ESLintUtils.getParserServices(context);
+    const checker = parserServices.program.getTypeChecker();
+    const checkNode = (
+      node: TSESTree.Node,
+      coercionType: "boolean" | "string"
+    ) => {
+      if (node.type !== "Identifier") {
+        return;
+      }
+      const tsNode = parserServices.esTreeNodeToTSNodeMap.get(node);
+      const typeString = checker.typeToString(
+        checker.getTypeAtLocation(tsNode)
+      );
+      if (!/\bSharedValue\b/.test(typeString)) {
+        return;
+      }
+
+      context.report({
+        messageId: getMessageId(coercionType),
+        node,
+        data: {
+          name: node.name,
+        },
+      });
+    };
+
+    return {
+      ConditionalExpression: ({ test }) => {
+        checkNode(test, "boolean");
+      },
+      IfStatement: ({ test }) => {
+        checkNode(test, "boolean");
+      },
+      LogicalExpression: ({ left, right }) => {
+        checkNode(left, "boolean");
+        checkNode(right, "boolean");
+      },
+      TemplateLiteral: ({ expressions }) => {
+        expressions.map((expression) => {
+          checkNode(expression, "string");
+        });
+      },
+    };
+  },
+});

--- a/tests/fixtures/invalid/shared-value-coercion-and-right.txt
+++ b/tests/fixtures/invalid/shared-value-coercion-and-right.txt
@@ -1,0 +1,16 @@
+import {useSharedValue, useDerivedValue} from 'react-native-reanimated'
+
+const Component: FC = () => {
+  const foo = useSharedValue('abc');
+
+  const bar = useDerivedValue(() => {
+    if (true && foo) {
+      return 1;
+    } else {
+      return 0;
+    }
+  });
+
+
+  return null;
+}

--- a/tests/fixtures/invalid/shared-value-coercion-and.txt
+++ b/tests/fixtures/invalid/shared-value-coercion-and.txt
@@ -1,0 +1,16 @@
+import {useSharedValue, useDerivedValue} from 'react-native-reanimated'
+
+const Component: FC = () => {
+  const foo = useSharedValue('abc');
+
+  const bar = useDerivedValue(() => {
+    if (foo && true) {
+      return 1;
+    } else {
+      return 0;
+    }
+  });
+
+
+  return null;
+}

--- a/tests/fixtures/invalid/shared-value-coercion-conditional.txt
+++ b/tests/fixtures/invalid/shared-value-coercion-conditional.txt
@@ -1,0 +1,9 @@
+import {useSharedValue, useDerivedValue} from 'react-native-reanimated'
+
+const Component: FC = () => {
+  const foo = useSharedValue(0);
+
+  const bar = useDerivedValue(() => foo ? 1 : 0);
+
+  return null;
+}

--- a/tests/fixtures/invalid/shared-value-coercion-if.txt
+++ b/tests/fixtures/invalid/shared-value-coercion-if.txt
@@ -1,0 +1,16 @@
+import {useSharedValue, useDerivedValue} from 'react-native-reanimated'
+
+const Component: FC = () => {
+  const foo = useSharedValue('abc');
+
+  const bar = useDerivedValue(() => {
+    if (foo) {
+      return 1;
+    } else {
+      return 0;
+    }
+  });
+
+
+  return null;
+}

--- a/tests/fixtures/invalid/shared-value-coercion-or-right.txt
+++ b/tests/fixtures/invalid/shared-value-coercion-or-right.txt
@@ -1,0 +1,16 @@
+import {useSharedValue, useDerivedValue} from 'react-native-reanimated'
+
+const Component: FC = () => {
+  const foo = useSharedValue('abc');
+
+  const bar = useDerivedValue(() => {
+    if (true || foo) {
+      return 1;
+    } else {
+      return 0;
+    }
+  });
+
+
+  return null;
+}

--- a/tests/fixtures/invalid/shared-value-coercion-or.txt
+++ b/tests/fixtures/invalid/shared-value-coercion-or.txt
@@ -1,0 +1,16 @@
+import {useSharedValue, useDerivedValue} from 'react-native-reanimated'
+
+const Component: FC = () => {
+  const foo = useSharedValue('abc');
+
+  const bar = useDerivedValue(() => {
+    if (foo || true) {
+      return 1;
+    } else {
+      return 0;
+    }
+  });
+
+
+  return null;
+}

--- a/tests/fixtures/invalid/shared-value-coercion-template-literal.txt
+++ b/tests/fixtures/invalid/shared-value-coercion-template-literal.txt
@@ -1,0 +1,11 @@
+import {useSharedValue, useDerivedValue} from 'react-native-reanimated'
+
+const Component: FC = () => {
+  const foo = useSharedValue('abc');
+
+  const bar = useDerivedValue(() =>
+    `${foo}def`
+  );
+
+  return null;
+}

--- a/tests/fixtures/valid/shared-value-coercion-and.txt
+++ b/tests/fixtures/valid/shared-value-coercion-and.txt
@@ -1,0 +1,16 @@
+import {useSharedValue, useDerivedValue} from 'react-native-reanimated'
+
+const Component: FC = () => {
+  const foo = useSharedValue('abc');
+
+  const bar = useDerivedValue(() => {
+    if (foo.value && true) {
+      return 1;
+    } else {
+      return 0;
+    }
+  });
+
+
+  return null;
+}

--- a/tests/fixtures/valid/shared-value-coercion-conditional-explicit.txt
+++ b/tests/fixtures/valid/shared-value-coercion-conditional-explicit.txt
@@ -1,0 +1,9 @@
+import {useSharedValue, useDerivedValue} from 'react-native-reanimated';
+
+const Component: FC = () => {
+  const foo = useSharedValue(0);
+
+  const bar = useDerivedValue(() => !!foo ? 1 : 0);
+
+  return null;
+};

--- a/tests/fixtures/valid/shared-value-coercion-conditional.txt
+++ b/tests/fixtures/valid/shared-value-coercion-conditional.txt
@@ -1,0 +1,9 @@
+import {useSharedValue, useDerivedValue} from 'react-native-reanimated';
+
+const Component: FC = () => {
+  const foo = useSharedValue(0);
+
+  const bar = useDerivedValue(() => foo.value ? 1 : 0);
+
+  return null;
+};

--- a/tests/fixtures/valid/shared-value-coercion-if.txt
+++ b/tests/fixtures/valid/shared-value-coercion-if.txt
@@ -1,0 +1,16 @@
+import {useSharedValue, useDerivedValue} from 'react-native-reanimated'
+
+const Component: FC = () => {
+  const foo = useSharedValue('abc');
+
+  const bar = useDerivedValue(() => {
+    if (foo.value) {
+      return 1;
+    } else {
+      return 0;
+    }
+  });
+
+
+  return null;
+}

--- a/tests/fixtures/valid/shared-value-coercion-template-literal-explicit.txt
+++ b/tests/fixtures/valid/shared-value-coercion-template-literal-explicit.txt
@@ -1,0 +1,9 @@
+import {useSharedValue, useDerivedValue} from 'react-native-reanimated'
+
+const Component: FC = () => {
+  const foo = useSharedValue('abc');
+
+  console.log(foo.toString());
+
+  return null;
+}

--- a/tests/fixtures/valid/shared-value-coercion-template-literal.txt
+++ b/tests/fixtures/valid/shared-value-coercion-template-literal.txt
@@ -1,0 +1,11 @@
+import {useSharedValue, useDerivedValue} from 'react-native-reanimated'
+
+const Component: FC = () => {
+  const foo = useSharedValue('abc');
+
+  const bar = useDerivedValue(() =>
+    `${foo.value}def`
+  );
+
+  return null;
+}

--- a/tests/no-shared-value-coercion.test.ts
+++ b/tests/no-shared-value-coercion.test.ts
@@ -1,0 +1,109 @@
+import path from "path";
+import fs from "fs";
+
+import { ESLintUtils } from "@typescript-eslint/experimental-utils";
+
+import rule from "../src/rules/no-shared-value-coercion";
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    project: "./tsconfig.eslint.json",
+    tsconfigRootDir: path.join(__dirname, "fixtures"),
+    sourceType: "module",
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+const code = (name: string) =>
+  fs.readFileSync(path.join(__dirname, name), "utf8");
+const VALID = "fixtures/valid";
+const files = fs.readdirSync(path.join(__dirname, VALID));
+const valid = files.map((file) => ({
+  code: code(path.join(VALID, file)),
+}));
+
+ruleTester.run("no-shared-value-coercion", rule, {
+  valid,
+  invalid: [
+    {
+      code: code("fixtures/invalid/shared-value-coercion-conditional.txt"),
+      errors: [
+        {
+          messageId: "NoSharedValueCoercionBooleanMessage",
+          data: {
+            name: "foo",
+          },
+        },
+      ],
+    },
+    {
+      code: code("fixtures/invalid/shared-value-coercion-if.txt"),
+      errors: [
+        {
+          messageId: "NoSharedValueCoercionBooleanMessage",
+          data: {
+            name: "foo",
+          },
+        },
+      ],
+    },
+    {
+      code: code("fixtures/invalid/shared-value-coercion-and.txt"),
+      errors: [
+        {
+          messageId: "NoSharedValueCoercionBooleanMessage",
+          data: {
+            name: "foo",
+          },
+        },
+      ],
+    },
+    {
+      code: code("fixtures/invalid/shared-value-coercion-and-right.txt"),
+      errors: [
+        {
+          messageId: "NoSharedValueCoercionBooleanMessage",
+          data: {
+            name: "foo",
+          },
+        },
+      ],
+    },
+    {
+      code: code("fixtures/invalid/shared-value-coercion-or.txt"),
+      errors: [
+        {
+          messageId: "NoSharedValueCoercionBooleanMessage",
+          data: {
+            name: "foo",
+          },
+        },
+      ],
+    },
+    {
+      code: code("fixtures/invalid/shared-value-coercion-or-right.txt"),
+      errors: [
+        {
+          messageId: "NoSharedValueCoercionBooleanMessage",
+          data: {
+            name: "foo",
+          },
+        },
+      ],
+    },
+    {
+      code: code("fixtures/invalid/shared-value-coercion-template-literal.txt"),
+      errors: [
+        {
+          messageId: "NoSharedValueCoercionStringMessage",
+          data: {
+            name: "foo",
+          },
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
Fixes #24 

Adds new `no-shared-value-coercion` rule to catch cases where you forgot to add `.value` and shared value is implicitly coerced to boolean/string